### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This change makes it so that dependabot opens a single PR instead of many separate PRs