### PR TITLE
fix: only enable rate limiter in production

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -64,5 +64,3 @@ jobs:
           retention-days: 30
     env:
       DATABASE_URL: "postgres://postgres:secret@postgres:5432/postgres"
-      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
-      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}

--- a/.github/workflows/lint-and-typecheck.yml
+++ b/.github/workflows/lint-and-typecheck.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   DATABASE_URL: "https://fake.com"
+  NODE_ENV: "test"
 
 jobs:
   lint-and-typecheck:
@@ -28,6 +29,3 @@ jobs:
 
       - name: Lint
         run: npm run lint
-    env:
-      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
-      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}

--- a/src/server/helpers/getRateLimiter.ts
+++ b/src/server/helpers/getRateLimiter.ts
@@ -1,0 +1,12 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+
+// Create a new ratelimiter, that allows 3 requests per 1 minute
+export const getRateLimiter = () =>
+  process.env.NODE_ENV === "production"
+    ? new Ratelimit({
+        redis: Redis.fromEnv(),
+        limiter: Ratelimit.slidingWindow(3, "1 m"),
+        analytics: true,
+      })
+    : undefined;


### PR DESCRIPTION
Should solve recurring issues with redis when running tests in CI.

Eg. when looking at server logs for
https://github.com/aberonni/improvdb/actions/runs/15385174287/job/43282354224?pr=105

```
 ⨯ Error [UrlError]: Upstash Redis client was passed an invalid URL. You should pass a URL starting with https. Received: "dependabot".
    at eval (src/server/api/routers/lessonPlan.ts:16:15)
  14 | // Create a new ratelimiter, that allows 3 requests per 1 minute
  15 | const ratelimit = new Ratelimit({
> 16 |   redis: Redis.fromEnv(),
     |               ^
  17 |   limiter: Ratelimit.slidingWindow(3, "1 m"),
  18 |   analytics: true,
  19 | });
  ```